### PR TITLE
Upgrade the framework and packages to dotnet 6.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
       - image: "hashicorp/terraform:light"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:3.1
+      - image: mcr.microsoft.com/dotnet/core/sdk:6.0
 
 references:
   workspace_root: &workspace_root "~"
@@ -71,7 +71,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_13.x | bash -
+            curl -sL https://deb.nodesource.com/setup_14.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
       - image: "hashicorp/terraform:light"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/core/sdk:6.0
+      - image: mcr.microsoft.com/dotnet/sdk:6.0
 
 references:
   workspace_root: &workspace_root "~"

--- a/BaseListener.Tests/BaseListener.Tests.csproj
+++ b/BaseListener.Tests/BaseListener.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
@@ -21,7 +21,7 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/BaseListener.Tests/Dockerfile
+++ b/BaseListener.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/BaseListener.Tests/Dockerfile
+++ b/BaseListener.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/core/sdk:6.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/BaseListener/BaseListener.csproj
+++ b/BaseListener/BaseListener.csproj
@@ -21,13 +21,13 @@
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.3" />
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.Logging" Version="1.49.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
   </ItemGroup>

--- a/BaseListener/Dockerfile
+++ b/BaseListener/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/core/sdk:6.0
 
 ARG LBHPACKAGESTOKEN
 ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN

--- a/BaseListener/Dockerfile
+++ b/BaseListener/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 ARG LBHPACKAGESTOKEN
 ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN

--- a/BaseListener/Properties/launchSettings.json
+++ b/BaseListener/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "Mock Lambda Test Tool": {
       "commandName": "Executable",
       "commandLineArgs": "--port 5050",
-      "workingDirectory": ".\\bin\\$(Configuration)\\netcoreapp3.1",
-      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-3.1.exe",
+      "workingDirectory": ".\\bin\\$(Configuration)\\net6.0",
+      "executablePath": "%USERPROFILE%\\.dotnet\\tools\\dotnet-lambda-test-tool-6.0.exe",
       "environmentVariables": {
         "ENVIRONMENT": "LocalDevelopment"
       }

--- a/BaseListener/aws-lambda-tools-defaults.json
+++ b/BaseListener/aws-lambda-tools-defaults.json
@@ -8,8 +8,8 @@
   "profile": "default",
   "region": "eu-west-2",
   "configuration": "Release",
-  "framework": "netcoreapp3.1",
-  "function-runtime": "dotnetcore3.1",
+  "framework": "net6.0",
+  "function-runtime": "dotnet6",
   "function-memory-size": 256,
   "function-timeout": 30,
   "function-handler": "BaseListener::BaseListener.SqsFunction::FunctionHandler"

--- a/BaseListener/build.cmd
+++ b/BaseListener/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package bin/release/netcoreapp3.1/base-listener.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package bin/release/net6.0/base-listener.zip

--- a/BaseListener/build.sh
+++ b/BaseListener/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package ./bin/release/netcoreapp3.1/base-listener.zip
+dotnet lambda package --configuration release --framework net6.0 --output-package ./bin/release/net6.0/base-listener.zip

--- a/BaseListener/serverless.yml
+++ b/BaseListener/serverless.yml
@@ -1,7 +1,7 @@
 service: base-listener
 provider:
   name: aws
-  runtime: dotnetcore3.1
+  runtime: dotnet6
   memorySize: 2048
   tracing:
     lambda: true
@@ -12,7 +12,7 @@ provider:
   region: eu-west-2
 
 package:
-  artifact: ./bin/release/netcoreapp3.1/base-listener.zip
+  artifact: ./bin/release/net6.0/base-listener.zip
 
 functions:
   BaseListener:


### PR DESCRIPTION
# What:
 - An upgrade of the dotnet version from 3.1 to 6.
 - An upgrade of some of the packages that are needed for the newer version to get deployed/run.

# Why:
 - It's a mandatory piece of work due to security as the current (3.1) version is reaching its end of life.
 - Better performance.
 - Newer features & syntax.

# Notes:
- This PR is based on the PR from [Charges Listener PR 101](https://github.com/LBHackney-IT/finance-charges-listener/pull/101).